### PR TITLE
[docs] Add missing 'install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project creates a `repos.json` that can be utilized by the [SAP InnerSource
 
 ## Installation
 
-`pip -r requirements.txt`
+`pip install -r requirements.txt`
 
 ## Usage
 


### PR DESCRIPTION
Add missing 'install' to the installation instructions