### PR TITLE
Add GitHub Enterprise support

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,3 +1,4 @@
 GH_TOKEN=' '
 TOPIC='inner-source'
 ORGANIZATION=' '
+GH_ENTERPRISE_URL=' '

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project creates a `repos.json` that can be utilized by the [SAP InnerSource
 1. Fill out the `.env` file with a _token_ from a user that has access to the organization to scan (listed below). Tokens should have admin:org or read:org access.
 1. Fill out the `.env` file with the exact _topic_ name you are searching for
 1. Fill out the `.env` file with the exact _organization_ that you want to search in
+1. (Optional) Fill out the `.env` file with the exact _URL_ of the GitHub Enterprise that you want to search in. Keep empty if you want to search in the  public `github.com`.
 1. Run `python3 ./crawler.py`, which will create a `repos.json` file containing the relevant metadata for the GitHub repos for the given _topic_
 1. Copy `repos.json` to your instance of the [SAP-InnerSource-Portal][SAP-InnerSource-Portal] and launch the portal as outlined in their installation instructions
 

--- a/crawler.py
+++ b/crawler.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     load_dotenv(dotenv_path)
 
     # Auth to GitHub.com
-    ghe = os.getenv("GH_ENTERPRISE_URL").strip()
+    ghe = os.getenv("GH_ENTERPRISE_URL", default="").strip()
     if ghe:
         gh = github3.github.GitHubEnterprise(ghe, token=os.getenv("GH_TOKEN"))
     else:

--- a/crawler.py
+++ b/crawler.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     # Auth to GitHub.com
     ghe = os.getenv("GH_ENTERPRISE_URL").strip()
     if ghe:
-        gh = github3.github.GitHubEnterprise(os.getenv("GH_ENTERPRISE_URL"), token=os.getenv("GH_TOKEN"))
+        gh = github3.github.GitHubEnterprise(ghe, token=os.getenv("GH_TOKEN"))
     else:
         gh = github3.login(token=os.getenv("GH_TOKEN"))
 

--- a/crawler.py
+++ b/crawler.py
@@ -15,7 +15,11 @@ if __name__ == "__main__":
     load_dotenv(dotenv_path)
 
     # Auth to GitHub.com
-    gh = github3.login(token=os.getenv("GH_TOKEN"))
+    ghe = os.getenv("GH_ENTERPRISE_URL").strip()
+    if ghe:
+        gh = github3.github.GitHubEnterprise(os.getenv("GH_ENTERPRISE_URL"), token=os.getenv("GH_TOKEN"))
+    else:
+        gh = github3.login(token=os.getenv("GH_TOKEN"))
 
     # Set the topic
     topic = os.getenv("TOPIC")


### PR DESCRIPTION
I needed to crawl an internal instance of GitHub Enterprise (GHE).
I added an environment variable `GH_ENTERPRISE_URL` to give the URL of the GHE instance. If left empty, it will crawl the public GitHub.
Close #19 
Hope you find that useful.
