### PR TITLE
Support multiple topics in repository search

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
         ORGANIZATION: ${{ secrets.ORGANIZATION }}
+        # for multiple topics, add them after a comma eg:
+        # TOPIC: inner-source,actions,security,python
         TOPIC: inner-source
 ```
 

--- a/crawler.py
+++ b/crawler.py
@@ -33,10 +33,12 @@ if __name__ == "__main__":
     # Set for repos that have already been added to the list
     repo_set = set()
     
+    # Iterate over topics, search for matching repositories, and process unique ones
     for topic in topics:
         search_string = "org:{} topic:{}".format(organization, topic)
         all_repos = gh.search_repositories(search_string)
         
+        # For each repo in the search results, check if it's unique and add it to repo_set
         for repo in all_repos:
             if repo is not None and repo.repository.full_name not in repo_set:
                 repo_set.add(repo.repository.full_name)

--- a/crawler.py
+++ b/crawler.py
@@ -10,7 +10,6 @@ import repo_activity.score
 from dotenv import load_dotenv
 
 if __name__ == "__main__":
-
     # Load env variables from file
     dotenv_path = join(dirname(__file__), ".env")
     load_dotenv(dotenv_path)
@@ -25,19 +24,19 @@ if __name__ == "__main__":
     # Set the topic
     topic = os.getenv("TOPIC")
     # If multiple topics, split topics by comma
-    topics = [t.strip() for t in topic.split(',')]
+    topics = [t.strip() for t in topic.split(",")]
     organization = os.getenv("ORGANIZATION")
 
     # Create empty list for repos
     repo_list = []
     # Set for repos that have already been added to the list
     repo_set = set()
-    
+
     # Iterate over topics, search for matching repositories, and process unique ones
     for topic in topics:
         search_string = "org:{} topic:{}".format(organization, topic)
         all_repos = gh.search_repositories(search_string)
-        
+
         # For each repo in the search results, check if it's unique and add it to repo_set
         for repo in all_repos:
             if repo is not None and repo.repository.full_name not in repo_set:
@@ -59,9 +58,9 @@ if __name__ == "__main__":
 
                 # fetch repository participation
                 participation = repo.repository.weekly_commit_count()
-                innersource_repo["_InnerSourceMetadata"]["participation"] = participation[
-                    "all"
-                ]
+                innersource_repo["_InnerSourceMetadata"][
+                    "participation"
+                ] = participation["all"]
 
                 # fetch contributing guidelines
                 try:
@@ -79,7 +78,9 @@ if __name__ == "__main__":
                 innersource_repo["_InnerSourceMetadata"]["topics"] = repo_topics.names
 
                 # calculate score
-                innersource_repo["score"] = repo_activity.score.calculate(innersource_repo)
+                innersource_repo["score"] = repo_activity.score.calculate(
+                    innersource_repo
+                )
 
                 repo_list.append(innersource_repo)
 

--- a/crawler.py
+++ b/crawler.py
@@ -23,6 +23,9 @@ if __name__ == "__main__":
 
     # Set the topic
     topic = os.getenv("TOPIC")
+    if not topic:
+        raise ValueError("TOPIC environment variable not set")
+
     # If multiple topics, split topics by comma
     topics = [t.strip() for t in topic.split(",")]
     organization = os.getenv("ORGANIZATION")


### PR DESCRIPTION
This pull request adds support for searching repositories with multiple topics. Previously, the script could only search for repositories with a single topic. With this change, users can now provide a comma-separated list of topics, and the script will search for repositories that have any of the specified topics.

- Modified the `topic` variable to be a list of topics obtained by splitting the `TOPIC` environment variable by commas.
- Updated the repository search loop to iterate over each topic in the `topics` list.
- Added a `repo_set` to keep track of repositories that have already been added to the `repo_list`, preventing duplicates.
- Removed `full_repository = repo.repository.refresh()` as it was being called.
- Updated README.md to reflect multiple topic support

If you have any questions or concerns, please don't hesitate to let me know, and I'll be happy to address them :) thanks!